### PR TITLE
DIR-7041 update unserved file types

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -36,8 +36,13 @@ http {
         add_header Content-Security-Policy "default-src *; font-src 'self' data: fonts.gstatic.com; style-src * 'unsafe-inline'; script-src * 'unsafe-inline' 'unsafe-eval'; img-src * data: 'unsafe-inline'; connect-src * 'unsafe-inline'; frame-src *; object-src 'none'; base-uri 'self'; frame-ancestors https://drugabuse.com/ https://*.drugabuse.com/; worker-src blob:;";
 
         # slow attacks by quickly returning unserved file types
-        location ~* \.(bak|zip|tar|gz|sql|php)$|/\. {
+        location ~* \.(bak|zip|tar|gz|sql|php|env|aspx)$|/\. {
              return 403;
+        }
+
+        # slow attacks by quickly returning ads.txt
+        location ~ ^/(ads\.txt)$ {
+            return 403;
         }
 
         # proxy drugabuse.com/wp-content/uploads/ -> s3 bucket


### PR DESCRIPTION
https://recoverybrands.atlassian.net/browse/DIR-7041

Brief Description:
DIR-7041 updated unserved file types

Example Links
https://staging.drugabuse.com/test.env
https://staging.drugabuse.com/test.aspx
https://staging.drugabuse.com/test.env.aspx
https://staging.drugabuse.com/ads.txt

Note: Only ads.txt should be blocked. We need robots.txt to load.

https://staging.drugabuse.com/robots.txt

Screenshot:
![image](https://github.com/American-Addiction-Centers/drugabuse-com-nginx/assets/86256771/a2532d7c-fe6d-468a-9bba-1d828fc2034f)
